### PR TITLE
Add temporary users locked to specific contests

### DIFF
--- a/apps/backend/src/database/Database.ts
+++ b/apps/backend/src/database/Database.ts
@@ -14,6 +14,7 @@ import {
     OrganisationMember,
     Problem,
     SiteNotification,
+    TemporaryUser,
 } from "@kontestis/models";
 import { ClusterSubmission } from "@kontestis/models";
 import { Contest } from "@kontestis/models";
@@ -78,6 +79,7 @@ import { migration_improve_generators } from "./migrations/0050_improve_generato
 import { migration_add_sample_clusters } from "./migrations/0051_add_sample_clusters";
 import { migration_generator_id_index } from "./migrations/0052_generator_id_index";
 import { migration_contest_chat_messages } from "./migrations/0053_contest_chat_messages";
+import { migration_add_temporary_users } from "./migrations/0054_add_temporary_users";
 
 export const Database = new ScylloClient<{
     users: User;
@@ -100,6 +102,7 @@ export const Database = new ScylloClient<{
     mail_preferences: MailPreference;
     edu_users: EduUser;
     managed_users: ManagedUser;
+    temporary_users: TemporaryUser;
     generators: Generator;
 }>({
     client: {
@@ -167,6 +170,7 @@ const migrations: Migration<any>[] = [
     migration_add_sample_clusters,
     migration_generator_id_index,
     migration_contest_chat_messages,
+    migration_add_temporary_users,
 ];
 
 export const initDatabase = async () => {

--- a/apps/backend/src/database/migrations/0054_add_temporary_users.ts
+++ b/apps/backend/src/database/migrations/0054_add_temporary_users.ts
@@ -1,0 +1,33 @@
+import { TemporaryUserV1 } from "@kontestis/models";
+import { Migration } from "scyllo";
+
+type MigrationType = {
+    temporary_users: TemporaryUserV1;
+};
+
+export const migration_add_temporary_users: Migration<MigrationType> = async (database, log) => {
+    await database.createTable(
+        "temporary_users",
+        true,
+        {
+            id: {
+                type: "bigint",
+            },
+            username: {
+                type: "text",
+            },
+            password: {
+                type: "text",
+            },
+            organisation_id: {
+                type: "bigint",
+            },
+            created_at: { type: "timestamp" },
+        },
+        "id"
+    );
+
+    await database.createIndex("temporary_users", "temporary_users_by_username", "username");
+
+    log("Done");
+};

--- a/apps/backend/src/extractors/extractUser.ts
+++ b/apps/backend/src/extractors/extractUser.ts
@@ -25,14 +25,16 @@ export const extractUser = async (req: Request): Promise<FullUser> => {
                 id: tokenData.id,
             });
 
+            if (!temporaryUser) {
+                throw new SafeError(StatusCodes.UNAUTHORIZED);
+            }
+
             return {
                 ...tokenData,
                 is_edu: false as const,
                 auth_source: authSource,
                 is_temporary: true,
-                temporary_data: temporaryUser
-                    ? { organisation_id: temporaryUser.organisation_id }
-                    : undefined,
+                temporary_data: { organisation_id: temporaryUser.organisation_id },
             };
         }
 

--- a/apps/backend/src/extractors/extractUser.ts
+++ b/apps/backend/src/extractors/extractUser.ts
@@ -20,6 +20,22 @@ export const extractUser = async (req: Request): Promise<FullUser> => {
 
         const { user: tokenData, authSource } = jwtData;
 
+        if (authSource === "temporary") {
+            const temporaryUser = await Database.selectOneFrom("temporary_users", "*", {
+                id: tokenData.id,
+            });
+
+            return {
+                ...tokenData,
+                is_edu: false as const,
+                auth_source: authSource,
+                is_temporary: true,
+                temporary_data: temporaryUser
+                    ? { organisation_id: temporaryUser.organisation_id }
+                    : undefined,
+            };
+        }
+
         const eduUser = await Database.selectOneFrom("edu_users", "*", {
             id: tokenData.id,
         });

--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -24,6 +24,7 @@ const AuthSourceType = Type.Union([
     Type.Literal("google"),
     Type.Literal("aai-edu"),
     Type.Literal("managed"),
+    Type.Literal("temporary"),
 ]);
 
 export const generateJwt = <

--- a/apps/backend/src/routes/auth/AuthHandler.ts
+++ b/apps/backend/src/routes/auth/AuthHandler.ts
@@ -13,11 +13,13 @@ import { extractIdFromParameters } from "../../utils/extractorUtils";
 import { respond } from "../../utils/response";
 import { AaiEduHandler } from "./AaiEduHandler";
 import ManagedHandler from "./ManagedHandler";
+import TemporaryHandler from "./TemporaryHandler";
 
 const AuthHandler = Router();
 
 AuthHandler.use("/aai-edu", AaiEduHandler);
 AuthHandler.use("/managed", ManagedHandler);
+AuthHandler.use("/temporary", TemporaryHandler);
 
 const OAuthSchema = Type.Object({
     credential: Type.String(),

--- a/apps/backend/src/routes/auth/TemporaryHandler.ts
+++ b/apps/backend/src/routes/auth/TemporaryHandler.ts
@@ -1,0 +1,203 @@
+import {
+    AdminPermissions,
+    ContestMemberPermissions,
+    DEFAULT_ELO,
+    hasAdminPermission,
+    OrganisationPermissions,
+} from "@kontestis/models";
+import { Type } from "@sinclair/typebox";
+import { hash, verify } from "argon2";
+import { Router } from "express";
+import { StatusCodes } from "http-status-codes";
+import { EMPTY_PERMISSIONS, grantPermission } from "permissio";
+
+import { Database } from "../../database/Database";
+import { SafeError } from "../../errors/SafeError";
+import { extractUser } from "../../extractors/extractUser";
+import { generateGravatarUrl, generateJwt } from "../../lib/auth";
+import { generateSnowflake } from "../../lib/snowflake";
+import { useValidation } from "../../middlewares/useValidation";
+import { randomSequence } from "../../utils/random";
+import { respond } from "../../utils/response";
+
+const TemporaryHandler = Router();
+
+const LoginSchema = Type.Object({
+    username: Type.String(),
+    password: Type.String({ minLength: 1, maxLength: 1024 }),
+});
+
+TemporaryHandler.post("/login", useValidation(LoginSchema, { body: true }), async (req, res) => {
+    const temporaryUser = await Database.selectOneFrom("temporary_users", "*", {
+        username: req.body.username,
+    });
+
+    if (!temporaryUser) throw new SafeError(StatusCodes.UNAUTHORIZED);
+
+    const verifyResult = await verify(temporaryUser.password, req.body.password);
+
+    if (!verifyResult) throw new SafeError(StatusCodes.UNAUTHORIZED);
+
+    const user = await Database.selectOneFrom("users", "*", {
+        id: temporaryUser.id,
+    });
+
+    if (!user) throw new SafeError(StatusCodes.INTERNAL_SERVER_ERROR);
+
+    return respond(res, StatusCodes.OK, { token: generateJwt(user.id, "temporary", {}) });
+});
+
+const stripDiacritics = (value: string) => value.normalize("NFD").replace(/[\u0300-\u036F]/g, "");
+
+const generateUsernameFromName = (fullName: string, prefix: string): string => {
+    const parts = fullName.trim().split(/\s+/);
+
+    const firstName = stripDiacritics(parts[0])
+        .toLowerCase()
+        .replace(/[^a-z]/g, "");
+    const lastName = stripDiacritics(parts[parts.length - 1])
+        .toLowerCase()
+        .replace(/[^a-z]/g, "");
+
+    const base = parts.length > 1 ? firstName.charAt(0) + lastName : firstName;
+
+    return `${prefix}_${base}`;
+};
+
+const BulkCreateSchema = Type.Object({
+    names: Type.Array(Type.String({ minLength: 1, maxLength: 128 }), {
+        minItems: 1,
+        maxItems: 500,
+    }),
+    contest_ids: Type.Array(Type.String(), { minItems: 1 }),
+    prefix: Type.String({ minLength: 1, maxLength: 64 }),
+});
+
+const resolveUniqueUsername = async (baseUsername: string): Promise<string> => {
+    let username = baseUsername;
+    let suffix = 1;
+    let existingUser = await Database.selectOneFrom("temporary_users", ["id"], {
+        username,
+    });
+
+    while (existingUser) {
+        suffix++;
+        username = `${baseUsername}${suffix}`;
+        existingUser = await Database.selectOneFrom("temporary_users", ["id"], {
+            username,
+        });
+    }
+
+    return username;
+};
+
+const createTemporaryUser = async (
+    name: string,
+    username: string,
+    organisationId: bigint,
+    contests: Array<{ id: bigint; organisation_id: bigint }>
+) => {
+    const plainPassword = randomSequence(6);
+    const passwordHash = await hash(plainPassword);
+
+    const id = generateSnowflake();
+    const syntheticEmail = `${username}@temporary.kontestis.local`;
+
+    await Database.insertInto("users", {
+        id,
+        email: syntheticEmail,
+        full_name: name,
+        picture_url: generateGravatarUrl(syntheticEmail),
+        permissions: EMPTY_PERMISSIONS,
+    });
+
+    await Database.insertInto("temporary_users", {
+        id,
+        username,
+        password: passwordHash,
+        organisation_id: organisationId,
+        created_at: new Date(),
+    });
+
+    const uniqueOrgIds = [...new Set(contests.map((c) => c.organisation_id.toString()))];
+
+    for (const orgId of uniqueOrgIds) {
+        const existingOrgMember = await Database.selectOneFrom("organisation_members", ["id"], {
+            organisation_id: BigInt(orgId),
+            user_id: id,
+        });
+
+        if (!existingOrgMember) {
+            await Database.insertInto("organisation_members", {
+                id: generateSnowflake(),
+                user_id: id,
+                organisation_id: BigInt(orgId),
+                elo: DEFAULT_ELO,
+                permissions: grantPermission(EMPTY_PERMISSIONS, OrganisationPermissions.VIEW),
+            });
+        }
+    }
+
+    for (const contest of contests) {
+        await Database.insertInto("contest_members", {
+            id: generateSnowflake(),
+            user_id: id,
+            contest_id: contest.id,
+            contest_permissions: grantPermission(0n, ContestMemberPermissions.VIEW),
+        });
+    }
+
+    return plainPassword;
+};
+
+TemporaryHandler.post(
+    "/bulk-create",
+    useValidation(BulkCreateSchema, { body: true }),
+    async (req, res) => {
+        const user = await extractUser(req);
+
+        if (!hasAdminPermission(user.permissions, AdminPermissions.ADMIN))
+            throw new SafeError(StatusCodes.FORBIDDEN);
+
+        const contestIds = req.body.contest_ids.map((id: string) => {
+            if (!/^\d+$/.test(id)) throw new SafeError(StatusCodes.BAD_REQUEST);
+
+            return BigInt(id);
+        });
+
+        const contests = await Promise.all(
+            contestIds.map(async (contestId: bigint) => {
+                const contest = await Database.selectOneFrom("contests", "*", { id: contestId });
+
+                if (!contest) throw new SafeError(StatusCodes.NOT_FOUND);
+
+                return contest;
+            })
+        );
+
+        const organisationId = contests[0].organisation_id;
+
+        const prefix = req.body.prefix.toLowerCase().replace(/[^\da-z]/g, "");
+
+        if (prefix.length === 0) throw new SafeError(StatusCodes.BAD_REQUEST);
+
+        const results: Array<{ name: string; username: string; password: string }> = [];
+
+        for (const name of req.body.names) {
+            const baseUsername = generateUsernameFromName(name, prefix);
+            const username = await resolveUniqueUsername(baseUsername);
+            const plainPassword = await createTemporaryUser(
+                name,
+                username,
+                organisationId,
+                contests
+            );
+
+            results.push({ name, username, password: plainPassword });
+        }
+
+        return respond(res, StatusCodes.OK, results);
+    }
+);
+
+export default TemporaryHandler;

--- a/apps/backend/src/routes/contest/ContestHandler.ts
+++ b/apps/backend/src/routes/contest/ContestHandler.ts
@@ -381,7 +381,6 @@ ContestHandler.get("/", async (req, res) => {
     const contests = await Database.selectFrom("contests", "*", {
         organisation_id: organisation.id,
     });
-    const returnedContests: Array<Contest> = [];
 
     const hasViewContestsPermission = await hasOrganisationPermission(
         req,

--- a/apps/backend/src/routes/contest/ContestHandler.ts
+++ b/apps/backend/src/routes/contest/ContestHandler.ts
@@ -350,7 +350,32 @@ ContestHandler.patch("/:contest_id", useValidation(ContestSchema), async (req, r
     respond(res, StatusCodes.OK);
 });
 
+const getContestsForTemporaryUser = async (userId: bigint): Promise<Contest[]> => {
+    const contestMembers = await Database.selectFrom(
+        "contest_members",
+        "*",
+        { user_id: userId },
+        "ALLOW FILTERING"
+    );
+
+    const memberContests = await Promise.all(
+        contestMembers
+            .filter((m) =>
+                hasContestPermission(m.contest_permissions, ContestMemberPermissions.VIEW)
+            )
+            .map((m) => Database.selectOneFrom("contests", "*", { id: m.contest_id }))
+    );
+
+    return memberContests.filter((c): c is Contest => c !== null);
+};
+
 ContestHandler.get("/", async (req, res) => {
+    const optionalUser = await extractOptionalUser(req);
+
+    if (optionalUser?.is_temporary) {
+        return respond(res, StatusCodes.OK, await getContestsForTemporaryUser(optionalUser.id));
+    }
+
     const organisation = await extractCurrentOrganisation(req);
 
     const contests = await Database.selectFrom("contests", "*", {
@@ -363,8 +388,6 @@ ContestHandler.get("/", async (req, res) => {
         OrganisationPermissions.VIEW_CONTEST,
         organisation.id
     );
-
-    const optionalUser = await extractOptionalUser(req);
 
     const isEduUser = optionalUser?.is_edu ?? false;
 
@@ -384,33 +407,22 @@ ContestHandler.get("/", async (req, res) => {
         contestMembersByContestId[member.contest_id.toString()] = member;
     }
 
-    for (const contest of contests) {
-        if (hasViewContestsPermission) {
-            returnedContests.push(contest);
-            continue;
-        }
+    const isContestVisible = (contest: Contest): boolean => {
+        if (hasViewContestsPermission) return true;
 
-        if (contest.public && contest.require_edu_verification && isEduUser) {
-            returnedContests.push(contest);
-            continue;
-        }
+        if (contest.public && contest.require_edu_verification && isEduUser) return true;
 
-        if (contest.public && !contest.require_edu_verification) {
-            returnedContests.push(contest);
-            continue;
-        }
+        if (contest.public && !contest.require_edu_verification) return true;
 
         const member = contestMembersByContestId[contest.id.toString()];
 
-        if (
-            member &&
+        return (
+            !!member &&
             hasContestPermission(member.contest_permissions, ContestMemberPermissions.VIEW)
-        ) {
-            returnedContests.push(contest);
-        }
-    }
+        );
+    };
 
-    return respond(res, StatusCodes.OK, returnedContests);
+    return respond(res, StatusCodes.OK, contests.filter(isContestVisible));
 });
 ContestHandler.get("/:contest_id/export/:user_id", async (req, res) => {
     const contest = await extractContest(req);

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { http, wrapAxios } from "./api/http";
 import { dashboardRoutes } from "./routers/dashboard";
 import { loginRoutes } from "./routers/login";
 import { organisationRoutes } from "./routers/organisation";
+import { temporaryRoutes } from "./routers/temporary";
 import { useAuthStore } from "./state/auth";
 import { useOrganisationStore } from "./state/organisation";
 import { useTokenStore } from "./state/token";
@@ -23,7 +24,7 @@ BigInt.prototype.toJSON = function () {
 };
 
 export const App = () => {
-    const { isLoggedIn, setUser, setIsLoggedIn, forceLogout, doForceLogout } = useAuthStore();
+    const { isLoggedIn, user, setUser, setIsLoggedIn, forceLogout, doForceLogout } = useAuthStore();
     const { token } = useTokenStore();
     const {
         isSelected,
@@ -68,8 +69,16 @@ export const App = () => {
             .catch(() => doForceLogout());
     }, [token]);
 
+    const isTemporary = isLoggedIn && user?.auth_source === "temporary";
+
     const matched = useRoutes(
-        isLoggedIn ? (isSelected ? dashboardRoutes : organisationRoutes) : loginRoutes
+        isLoggedIn
+            ? isTemporary
+                ? temporaryRoutes
+                : isSelected
+                ? dashboardRoutes
+                : organisationRoutes
+            : loginRoutes
     );
 
     useEffect(() => {
@@ -89,6 +98,13 @@ export const App = () => {
 
         doForceLogout(false);
     }, [location, forceLogout]);
+
+    useEffect(() => {
+        if (!isLoggedIn || !user?.is_temporary || !user?.temporary_data) return;
+
+        setOrganisationId(user.temporary_data.organisation_id);
+        setIsOrganisationSelected(true);
+    }, [isLoggedIn, user]);
 
     useEffect(() => {
         if (!isLoggedIn) return;

--- a/apps/frontend/src/hooks/auth/useBulkCreateTemporaryUsers.ts
+++ b/apps/frontend/src/hooks/auth/useBulkCreateTemporaryUsers.ts
@@ -1,0 +1,26 @@
+import { Snowflake } from "@kontestis/models";
+import { useMutation } from "react-query";
+
+import { http, invalidateOnSuccess, MutationHandler, wrapAxios } from "../../api/http";
+
+type BulkCreateVariables = {
+    names: string[];
+    contest_ids: string[];
+    prefix: string;
+};
+
+type BulkCreateResult = Array<{
+    name: string;
+    username: string;
+    password: string;
+}>;
+
+export const useBulkCreateTemporaryUsers: MutationHandler<
+    BulkCreateVariables,
+    BulkCreateResult,
+    Snowflake
+> = (contestId, options) =>
+    useMutation(
+        (variables) => wrapAxios(http.post("/auth/temporary/bulk-create", variables)),
+        invalidateOnSuccess([["contests", contestId, "members"]], options)
+    );

--- a/apps/frontend/src/pages/auth/LoginPage.tsx
+++ b/apps/frontend/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { CredentialResponse, GoogleLogin, GoogleOAuthProvider } from "@react-oauth/google";
 import React, { FC, useCallback, useMemo, useState } from "react";
 import { useLocation } from "react-router";
+import { Link } from "react-router-dom";
 
 import { http, ServerData } from "../../api/http";
 import { AaiEduButton } from "../../components/AaiEduButton";
@@ -100,6 +101,11 @@ const LoginBase: FC = () => {
                             </div>
                         </div>
                     </div>
+                    <span tw={"text-sm text-neutral-500"}>
+                        <Link to={"/temp-login"} tw={"text-sky-600"}>
+                            Log in as temporary user
+                        </Link>
+                    </span>
                 </div>
             </TitledSection>
         </div>

--- a/apps/frontend/src/pages/auth/TemporaryLoginPage.tsx
+++ b/apps/frontend/src/pages/auth/TemporaryLoginPage.tsx
@@ -1,0 +1,93 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import React, { FC, useState } from "react";
+import { useForm } from "react-hook-form";
+import { Link } from "react-router-dom";
+import { theme } from "twin.macro";
+import { z } from "zod";
+
+import { http, wrapAxios } from "../../api/http";
+import { SimpleButton } from "../../components/SimpleButton";
+import { TitledInput } from "../../components/TitledInput";
+import { TitledSection } from "../../components/TitledSection";
+import { useTokenStore } from "../../state/token";
+
+const FormData = z.object({
+    username: z.string().min(1),
+    password: z.string().min(1).max(1024),
+});
+
+export const TemporaryLoginPage: FC = () => {
+    const { setToken } = useTokenStore();
+    const [error, setError] = useState<string | undefined>();
+    const [loading, setLoading] = useState(false);
+
+    const {
+        handleSubmit,
+        register,
+        formState: { errors },
+    } = useForm<z.infer<typeof FormData>>({
+        resolver: zodResolver(FormData),
+    });
+
+    const onSubmit = handleSubmit(async (data) => {
+        setError();
+        setLoading(true);
+
+        try {
+            const result = await wrapAxios<{ token: string }>(
+                http.post("/auth/temporary/login", data)
+            );
+
+            setToken(result.token);
+        } catch {
+            setError("Invalid username or password");
+        } finally {
+            setLoading(false);
+        }
+    });
+
+    return (
+        <div tw={"w-full md:max-w-[768px] mt-20"}>
+            <TitledSection title={"Temporary User Login"}>
+                <div tw={"w-full flex flex-col items-center justify-center gap-8 pb-12 pt-6"}>
+                    {error && <span tw={"text-red-500 text-lg"}>{error}</span>}
+                    <div tw={"w-full flex flex-col gap-6 items-center max-w-[256px]"}>
+                        <form onSubmit={onSubmit} tw={"w-full"}>
+                            <div tw={"flex flex-col gap-4 items-center w-full"}>
+                                <TitledInput
+                                    label={"Username:"}
+                                    bigLabel
+                                    tw={"pt-0 max-w-full"}
+                                    placeholder={"temp_abc12def"}
+                                    error={errors.username?.message}
+                                    {...register("username")}
+                                />
+                                <TitledInput
+                                    label={"Password:"}
+                                    type={"password"}
+                                    bigLabel
+                                    tw={"pt-0 max-w-full"}
+                                    placeholder={"\u2022".repeat(12)}
+                                    error={errors.password?.message}
+                                    {...register("password")}
+                                />
+                                <SimpleButton
+                                    tw={"w-full"}
+                                    color={theme`colors.red.300`}
+                                    disabled={loading}
+                                >
+                                    Log in
+                                </SimpleButton>
+                            </div>
+                        </form>
+                        <span tw={"text-base text-center"}>
+                            <Link to={"/"} tw={"text-sky-600"}>
+                                Back to main login
+                            </Link>
+                        </span>
+                    </div>
+                </div>
+            </TitledSection>
+        </div>
+    );
+};

--- a/apps/frontend/src/pages/management/contest/participants/BulkCreateTemporaryUsers.tsx
+++ b/apps/frontend/src/pages/management/contest/participants/BulkCreateTemporaryUsers.tsx
@@ -1,0 +1,126 @@
+import React, { FC, useState } from "react";
+import tw from "twin.macro";
+
+import { SimpleButton } from "../../../../components/SimpleButton";
+import { TitledInput } from "../../../../components/TitledInput";
+import { useContestContext } from "../../../../context/constestContext";
+import { useBulkCreateTemporaryUsers } from "../../../../hooks/auth/useBulkCreateTemporaryUsers";
+
+type CreatedUser = {
+    name: string;
+    username: string;
+    password: string;
+};
+
+export const BulkCreateTemporaryUsers: FC = () => {
+    const { contest } = useContestContext();
+    const [names, setNames] = useState("");
+    const [prefix, setPrefix] = useState("");
+    const [results, setResults] = useState<CreatedUser[]>([]);
+
+    const bulkCreateMutation = useBulkCreateTemporaryUsers(contest.id, {
+        onSuccess: (data) => {
+            setResults(data);
+            setNames("");
+        },
+    });
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+
+        const nameList = names
+            .split("\n")
+            .map((n) => n.trim())
+            .filter((n) => n.length > 0);
+
+        if (nameList.length === 0 || prefix.trim().length === 0) return;
+
+        bulkCreateMutation.mutate({
+            names: nameList,
+            contest_ids: [contest.id.toString()],
+            prefix: prefix.trim(),
+        });
+    };
+
+    const downloadCsv = () => {
+        const header = "Name,Username,Password\n";
+        const rows = results.map((r) => `${r.name},${r.username},${r.password}`).join("\n");
+        const blob = new Blob([header + rows], { type: "text/csv" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+
+        a.href = url;
+        a.download = `temporary_users_${contest.name.replace(/[^\dA-Za-z]/g, "_")}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    return (
+        <div tw={"flex flex-col gap-4"}>
+            <span tw={"text-lg font-bold"}>Bulk Create Temporary Users</span>
+            <form onSubmit={handleSubmit}>
+                <div tw={"flex flex-col gap-2"}>
+                    <TitledInput
+                        label={"Username prefix (e.g. nap2026):"}
+                        bigLabel
+                        tw={"pt-0 max-w-full"}
+                        placeholder={"nap2026"}
+                        value={prefix}
+                        onChange={(event) => setPrefix(event.target.value)}
+                    />
+                    <span tw={"text-base"}>Names (one per line):</span>
+                    <textarea
+                        tw={
+                            "w-full h-32 py-1 px-2 bg-neutral-200 border border-solid border-neutral-300 text-base outline-none hover:bg-neutral-300 resize-y font-[inherit]"
+                        }
+                        value={names}
+                        onChange={(event) => setNames(event.target.value)}
+                        placeholder={"Alice\nBob\nCharlie"}
+                    />
+                    <div tw={"flex gap-2 items-center"}>
+                        <SimpleButton disabled={bulkCreateMutation.isLoading}>
+                            {bulkCreateMutation.isLoading ? "Creating..." : "Create Users"}
+                        </SimpleButton>
+                        {bulkCreateMutation.isError && (
+                            <span tw={"text-red-500"}>Failed to create users</span>
+                        )}
+                    </div>
+                </div>
+            </form>
+            {results.length > 0 && (
+                <div tw={"flex flex-col gap-2"}>
+                    <div tw={"flex gap-2 items-center justify-between"}>
+                        <span tw={"font-bold"}>Created {results.length} temporary user(s):</span>
+                        <SimpleButton onClick={downloadCsv}>Download CSV</SimpleButton>
+                    </div>
+                    <div tw={"overflow-x-auto"}>
+                        <table
+                            css={[
+                                tw`w-full border-collapse`,
+                                tw`[& th]:(text-left p-2 bg-neutral-300 border border-solid border-neutral-400)`,
+                                tw`[& td]:(p-2 bg-neutral-100 border border-solid border-neutral-300 font-mono text-sm)`,
+                            ]}
+                        >
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Username</th>
+                                    <th>Password</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {results.map((user) => (
+                                    <tr key={user.username}>
+                                        <td>{user.name}</td>
+                                        <td>{user.username}</td>
+                                        <td>{user.password}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/apps/frontend/src/pages/management/contest/participants/ContestParticipantsPage.tsx
+++ b/apps/frontend/src/pages/management/contest/participants/ContestParticipantsPage.tsx
@@ -24,6 +24,7 @@ import { useModifyContestMember } from "../../../../hooks/contest/participants/u
 import { useRemoveParticipant } from "../../../../hooks/contest/participants/useRemoveParticipant";
 import { useTranslation } from "../../../../hooks/useTranslation";
 import { useAuthStore } from "../../../../state/auth";
+import { BulkCreateTemporaryUsers } from "./BulkCreateTemporaryUsers";
 
 type MemberBoxProperties = {
     member: ContestMemberWithInfo;
@@ -209,6 +210,9 @@ export const ContestParticipantsPage: FC = () => {
                     )
                 )}
             </div>
+            <div tw={"w-[calc(100% + 1rem)] -mx-2 h-[1px] bg-neutral-400 my-2"}></div>
+            <BulkCreateTemporaryUsers />
+            <div tw={"w-[calc(100% + 1rem)] -mx-2 h-[1px] bg-neutral-400 my-2"}></div>
             {members && (
                 <>
                     {members

--- a/apps/frontend/src/pages/temporary/TemporaryContestsPage.tsx
+++ b/apps/frontend/src/pages/temporary/TemporaryContestsPage.tsx
@@ -1,0 +1,23 @@
+import { FC } from "react";
+
+import { PageTitle } from "../../components/PageTitle";
+import { useAllContests } from "../../hooks/contest/useAllContests";
+import { useMappedContests } from "../../hooks/contest/useMappedContests";
+import { useSelfContestMembers } from "../../hooks/contest/useSelfContestMembers";
+import { ContestsTable } from "../contests/ContestsTable";
+
+export const TemporaryContestsPage: FC = () => {
+    const { isSuccess, data: contests } = useAllContests();
+    const { data: contestMembers } = useSelfContestMembers();
+
+    const completeContests = useMappedContests(contests, contestMembers);
+
+    if (!isSuccess) return <span>Loading...</span>;
+
+    return (
+        <div tw={"w-full flex flex-col"}>
+            <PageTitle>Your Contests</PageTitle>
+            <ContestsTable contests={completeContests} />
+        </div>
+    );
+};

--- a/apps/frontend/src/pages/temporary/TemporaryLayout.tsx
+++ b/apps/frontend/src/pages/temporary/TemporaryLayout.tsx
@@ -1,0 +1,53 @@
+import { FC, useCallback } from "react";
+import { FiClock, FiLogOut } from "react-icons/all";
+import { Outlet } from "react-router";
+import tw from "twin.macro";
+
+import { NavElement } from "../../components/NavElement";
+import { useAuthStore } from "../../state/auth";
+import { useTokenStore } from "../../state/token";
+
+export const TemporaryLayout: FC = () => {
+    const { user } = useAuthStore();
+    const { setToken } = useTokenStore();
+
+    const logout = useCallback(() => {
+        setToken("");
+    }, [setToken]);
+
+    return (
+        <div tw={"w-full flex flex-col items-center"}>
+            <div
+                css={[
+                    tw`w-full p-4 pl-6 flex flex-col sm:flex-row items-center justify-between gap-6 flex-wrap text-base`,
+                    tw`bg-slate-100`,
+                    tw`border-solid border-l-0 border-r-0 border-t-0 border-b-2 border-neutral-300`,
+                ]}
+            >
+                <div tw={"flex gap-6 flex-col sm:flex-row items-center"}>
+                    <span tw={"font-bold text-neutral-700"}>{user.full_name}</span>
+                    <NavElement
+                        item={{
+                            display: "Contests",
+                            href: "",
+                            icon: FiClock,
+                        }}
+                    />
+                </div>
+                <div
+                    tw={"flex items-center hover:text-red-800 transition-all cursor-pointer"}
+                    onClick={logout}
+                >
+                    <FiLogOut size={"16px"} />
+                </div>
+            </div>
+            <div
+                tw={
+                    "flex flex-col w-full max-w-[1000px] items-center justify-start gap-4 py-6 px-12"
+                }
+            >
+                <Outlet />
+            </div>
+        </div>
+    );
+};

--- a/apps/frontend/src/routers/login.tsx
+++ b/apps/frontend/src/routers/login.tsx
@@ -4,6 +4,7 @@ import { Navigate, RouteObject } from "react-router-dom";
 import { AaiLoginPage } from "../pages/auth/AaiLoginPage";
 import { LoginPage } from "../pages/auth/LoginPage";
 import { RegisterPage } from "../pages/auth/RegisterPage";
+import { TemporaryLoginPage } from "../pages/auth/TemporaryLoginPage";
 import { Root } from "../pages/Root";
 
 export const loginRoutes: RouteObject[] = [
@@ -22,6 +23,10 @@ export const loginRoutes: RouteObject[] = [
             {
                 path: "aai-login",
                 element: <AaiLoginPage />,
+            },
+            {
+                path: "temp-login",
+                element: <TemporaryLoginPage />,
             },
             {
                 path: "*",

--- a/apps/frontend/src/routers/temporary.tsx
+++ b/apps/frontend/src/routers/temporary.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Navigate, RouteObject } from "react-router-dom";
+
+import { ContestThreadPage } from "../pages/contests/ContestThreadPage";
+import { ContestViewPage } from "../pages/contests/ContestViewPage";
+import { ProblemViewPage } from "../pages/problems/ProblemViewPage";
+import { SubmissionViewPage } from "../pages/submissions/SubmissionViewPage";
+import { TemporaryContestsPage } from "../pages/temporary/TemporaryContestsPage";
+import { TemporaryLayout } from "../pages/temporary/TemporaryLayout";
+
+export const temporaryRoutes: RouteObject[] = [
+    {
+        path: "/",
+        element: <TemporaryLayout />,
+        children: [
+            {
+                index: true,
+                element: <TemporaryContestsPage />,
+            },
+            {
+                path: "contest/:contestId",
+                element: <ContestViewPage />,
+            },
+            {
+                path: "contest/:contestId/thread/:threadId",
+                element: <ContestThreadPage />,
+            },
+            {
+                path: "submission/:submissionId",
+                element: <SubmissionViewPage />,
+            },
+            {
+                path: "problem/:problemId",
+                element: <ProblemViewPage />,
+            },
+            {
+                path: "*",
+                element: <Navigate to={"/"} replace />,
+            },
+        ],
+    },
+];

--- a/packages/models/src/User.ts
+++ b/packages/models/src/User.ts
@@ -56,6 +56,16 @@ export type ManagedUserV1 = {
 
 export type ManagedUser = ManagedUserV1;
 
+export type TemporaryUserV1 = {
+    id: Snowflake;
+    username: string;
+    password: string;
+    organisation_id: Snowflake;
+    created_at?: Date;
+};
+
+export type TemporaryUser = TemporaryUserV1;
+
 export type EduUser = EduUserV1;
 
 export type EduUserLinksV1 = {
@@ -65,10 +75,12 @@ export type EduUserLinksV1 = {
 
 export type User = UserV6;
 
-export type AuthSource = "google" | "aai-edu" | "managed";
+export type AuthSource = "google" | "aai-edu" | "managed" | "temporary";
 
 export type FullUser = User & {
     auth_source: AuthSource;
+    is_temporary?: boolean;
+    temporary_data?: { organisation_id: Snowflake };
 } & (
         | {
               is_edu: false;


### PR DESCRIPTION
## Summary
- Adds a new **"temporary" auth source** with username/password login, allowing admins to bulk-create contest-locked users from a list of names
- Usernames are generated from the full name with a configurable prefix (e.g. `nap2026_vpavlica`), with diacritics stripping and automatic deduplication
- Temporary users see a **stripped-down frontend** with only their assigned contests visible — no dashboard, org picker, admin, or management pages
- Includes a **bulk-create UI** in the contest management participants page with CSV download for generated credentials

## Test plan
- [ ] Create temporary users via contest management > participants > "Bulk Create Temporary Users" with a prefix and list of names
- [ ] Verify generated usernames follow the `prefix_firstlastname` pattern with diacritics stripped
- [ ] Download CSV and verify credentials are correct
- [ ] Log in as a temporary user at `/temp-login` with generated credentials
- [ ] Verify temporary user only sees assigned contest(s) and cannot navigate to dashboard, admin, or other sections
- [ ] Verify temporary user can submit solutions and view problems within their contest
- [ ] Verify temporary user gets 403 on admin/org management API endpoints
- [ ] Verify duplicate name handling appends numeric suffix (e.g. `nap2026_vpavlica2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)