### PR TITLE
Fix frontend permission checks to match backend 3-tier cascade

### DIFF
--- a/apps/frontend/src/components/CanContestMember.tsx
+++ b/apps/frontend/src/components/CanContestMember.tsx
@@ -1,34 +1,19 @@
-import {
-    AdminPermissions,
-    ContestMember,
-    ContestMemberPermissions,
-    hasAdminPermission,
-    hasContestPermission,
-} from "@kontestis/models";
+import { Contest, ContestMember, ContestMemberPermissions } from "@kontestis/models";
 import { FC, ReactNode } from "react";
 
-import { useAuthStore } from "../state/auth";
+import { useContestPermission } from "../hooks/contest/useContestPermission";
 
 type Properties = {
-    member: ContestMember | undefined;
+    contest: Pick<Contest, "id" | "organisation_id">;
+    member?: ContestMember;
     permission: ContestMemberPermissions;
-    adminPermission: AdminPermissions;
     children: ReactNode | ReactNode[];
 };
 
-export const CanContestMember: FC<Properties> = ({
-    member,
-    permission,
-    adminPermission,
-    children,
-}) => {
-    const { user } = useAuthStore();
+export const CanContestMember: FC<Properties> = ({ contest, member, permission, children }) => {
+    const allowed = useContestPermission(permission, contest, member);
 
-    if (
-        (!member || !hasContestPermission(member.contest_permissions, permission)) &&
-        !hasAdminPermission(user.permissions, adminPermission)
-    )
-        return <></>;
+    if (!allowed) return <></>;
 
     return <>{children}</>;
 };

--- a/apps/frontend/src/hooks/contest/useContestPermission.ts
+++ b/apps/frontend/src/hooks/contest/useContestPermission.ts
@@ -1,0 +1,38 @@
+import {
+    ContestMember,
+    ContestMemberPermissions,
+    hasContestPermission,
+    Snowflake,
+} from "@kontestis/models";
+import { useMemo } from "react";
+
+import { useAuthStore } from "../../state/auth";
+import { useSelfOrganisationMembers } from "../organisation/useSelfOrganisationMembers";
+import { useSelfContestMembers } from "./useSelfContestMembers";
+
+export const useContestPermission = (
+    permission: ContestMemberPermissions,
+    contest: { id: Snowflake; organisation_id: Snowflake } | undefined,
+    member?: ContestMember
+): boolean => {
+    const { user } = useAuthStore();
+    const { data: selfContestMembers } = useSelfContestMembers();
+    const { data: selfOrgMembers } = useSelfOrganisationMembers();
+
+    return useMemo(() => {
+        if (!contest) return false;
+
+        const contestMember =
+            member ?? selfContestMembers?.find((m) => m.contest_id === contest.id);
+        const orgMember = selfOrgMembers?.find(
+            (m) => m.organisation_id === contest.organisation_id
+        );
+
+        return hasContestPermission(
+            contestMember?.contest_permissions ?? 0n,
+            permission,
+            orgMember?.permissions,
+            user.permissions
+        );
+    }, [contest, member, selfContestMembers, selfOrgMembers, permission, user.permissions]);
+};

--- a/apps/frontend/src/pages/contests/ContestViewPage.tsx
+++ b/apps/frontend/src/pages/contests/ContestViewPage.tsx
@@ -1,4 +1,4 @@
-import { AdminPermissions, hasAdminPermission } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useMemo } from "react";
 import { FiList } from "react-icons/all";
 import { useParams } from "react-router";
@@ -9,12 +9,12 @@ import { Table, TableHeadItem, TableHeadRow, TableItem, TableRow } from "../../c
 import { TitledSection } from "../../components/TitledSection";
 import { useAllContestAnnouncements } from "../../hooks/contest/announcements/useAllContestAnnouncements";
 import { useContest } from "../../hooks/contest/useContest";
+import { useContestPermission } from "../../hooks/contest/useContestPermission";
 import { useSelfContestMembers } from "../../hooks/contest/useSelfContestMembers";
 import { useAllProblems } from "../../hooks/problem/useAllProblems";
 import { useAllProblemScores } from "../../hooks/problem/useAllProblemScores";
 import { ContestStatusStyleColorMap, useContestStatus } from "../../hooks/useContestStatus";
 import { useTranslation } from "../../hooks/useTranslation";
-import { useAuthStore } from "../../state/auth";
 import { ContestChatSection } from "./ContestChatSection";
 import { Leaderboard } from "./Leaderboard";
 
@@ -24,8 +24,6 @@ type Properties = {
 
 export const ContestViewPage: FC = () => {
     const { contestId } = useParams<Properties>();
-
-    const { user } = useAuthStore();
 
     const { data: contest } = useContest(BigInt(contestId ?? 0n));
     const { data: problems } = useAllProblems(contest?.id, {
@@ -50,6 +48,12 @@ export const ContestViewPage: FC = () => {
             Date.now() < contest.start_time.getTime() + 1000 * contest.duration_seconds
         );
     }, [contest]);
+
+    const canViewPrivate = useContestPermission(
+        ContestMemberPermissions.VIEW_PRIVATE,
+        contest,
+        selfMember
+    );
 
     const problemScores = useAllProblemScores();
 
@@ -92,10 +96,7 @@ export const ContestViewPage: FC = () => {
                     {selfMember && <ContestChatSection contestId={contest.id} />}
                 </div>
             )}
-            {(contestStatus.status !== "pending" ||
-                // TODO: Replace with actual permission check
-                (problems && problems.length > 0) ||
-                hasAdminPermission(user.permissions, AdminPermissions.VIEW_CONTEST)) && (
+            {(contestStatus.status !== "pending" || canViewPrivate) && (
                 <Table tw={"w-full"}>
                     <thead>
                         <TableHeadRow>
@@ -141,7 +142,7 @@ export const ContestViewPage: FC = () => {
                     </tbody>
                 </Table>
             )}
-            <Leaderboard contest={contest} problems={problems ?? []} />
+            <Leaderboard contest={contest} problems={problems ?? []} selfMember={selfMember} />
         </div>
     );
 };

--- a/apps/frontend/src/pages/contests/Leaderboard.tsx
+++ b/apps/frontend/src/pages/contests/Leaderboard.tsx
@@ -1,10 +1,16 @@
-import { AdminPermissions, Contest, hasAdminPermission, ProblemWithScore } from "@kontestis/models";
+import {
+    Contest,
+    ContestMember,
+    ContestMemberPermissions,
+    ProblemWithScore,
+} from "@kontestis/models";
 import React, { FC, useMemo } from "react";
 import tw from "twin.macro";
 
 import { ProblemScoreBox } from "../../components/ProblemScoreBox";
 import { Table, TableHeadItem, TableHeadRow, TableItem, TableRow } from "../../components/Table";
 import { useAllContestMembers } from "../../hooks/contest/participants/useAllContestMembers";
+import { useContestPermission } from "../../hooks/contest/useContestPermission";
 import { useTranslation } from "../../hooks/useTranslation";
 import { useAuthStore } from "../../state/auth";
 import { R } from "../../util/remeda";
@@ -12,20 +18,24 @@ import { R } from "../../util/remeda";
 type Properties = {
     contest: Contest;
     problems: ProblemWithScore[];
+    selfMember: ContestMember | undefined;
 };
 
-export const Leaderboard: FC<Properties> = ({ contest, problems }) => {
+export const Leaderboard: FC<Properties> = ({ contest, problems, selfMember }) => {
     const { user } = useAuthStore();
 
     const contestEnded =
         Date.now() >= contest.start_time.getTime() + contest.duration_seconds * 1000;
 
+    const canViewPrivate = useContestPermission(
+        ContestMemberPermissions.VIEW_PRIVATE,
+        contest,
+        selfMember
+    );
+
     const leaderboardVisible = useMemo(
-        () =>
-            contest.show_leaderboard_during_contest ||
-            contestEnded ||
-            hasAdminPermission(user.permissions, AdminPermissions.VIEW_CONTEST),
-        [contest, contestEnded, user]
+        () => contest.show_leaderboard_during_contest || contestEnded || canViewPrivate,
+        [contest, contestEnded, canViewPrivate]
     );
 
     const { isSuccess, data } = useAllContestMembers([contest.id, {}], {

--- a/apps/frontend/src/pages/management/ManagementPage.tsx
+++ b/apps/frontend/src/pages/management/ManagementPage.tsx
@@ -1,9 +1,4 @@
-import {
-    AdminPermissions,
-    ContestMemberPermissions,
-    hasAdminPermission,
-    hasContestPermission,
-} from "@kontestis/models";
+import { ContestMemberPermissions, hasContestPermission } from "@kontestis/models";
 import { FC, useMemo, useState } from "react";
 import { FiPlus } from "react-icons/all";
 
@@ -14,6 +9,7 @@ import { Table, TableHeadItem, TableHeadRow } from "../../components/Table";
 import { useAllContests } from "../../hooks/contest/useAllContests";
 import { useMappedContests } from "../../hooks/contest/useMappedContests";
 import { useSelfContestMembers } from "../../hooks/contest/useSelfContestMembers";
+import { useSelfOrganisationMembers } from "../../hooks/organisation/useSelfOrganisationMembers";
 import { useTranslation } from "../../hooks/useTranslation";
 import { useAuthStore } from "../../state/auth";
 import { ContestListItem } from "../contests/ContestListItem";
@@ -26,17 +22,23 @@ export const ManagementPage: FC = () => {
     const { data: contestMembers } = useSelfContestMembers();
 
     const { user } = useAuthStore();
+    const { data: orgMembers } = useSelfOrganisationMembers();
 
     const completeContests = useMappedContests(contests, contestMembers);
 
     const myContests = useMemo(
         () =>
-            completeContests.filter(
-                (it) =>
-                    hasContestPermission(it.permissions, ContestMemberPermissions.VIEW_PRIVATE) ||
-                    hasAdminPermission(user.permissions, AdminPermissions.VIEW_CONTEST)
-            ),
-        [completeContests]
+            completeContests.filter((it) => {
+                const orgMember = orgMembers?.find((m) => m.organisation_id === it.organisation_id);
+
+                return hasContestPermission(
+                    it.permissions,
+                    ContestMemberPermissions.VIEW_PRIVATE,
+                    orgMember?.permissions,
+                    user.permissions
+                );
+            }),
+        [completeContests, orgMembers, user.permissions]
     );
 
     const { t } = useTranslation();

--- a/apps/frontend/src/pages/management/contest/ContestManagementLayout.tsx
+++ b/apps/frontend/src/pages/management/contest/ContestManagementLayout.tsx
@@ -1,9 +1,4 @@
-import {
-    AdminPermissions,
-    ContestMemberPermissions,
-    hasAdminPermission,
-    hasContestPermission,
-} from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useEffect, useMemo } from "react";
 import {
     FiActivity,
@@ -20,9 +15,9 @@ import { SubRouteNavBar } from "../../../components/SubRouteNavBar";
 import { Translated } from "../../../components/Translated";
 import { ContestContext } from "../../../context/constestContext";
 import { useContest } from "../../../hooks/contest/useContest";
+import { useContestPermission } from "../../../hooks/contest/useContestPermission";
 import { useSelfContestMembers } from "../../../hooks/contest/useSelfContestMembers";
 import { useTranslation } from "../../../hooks/useTranslation";
-import { useAuthStore } from "../../../state/auth";
 
 type PathParameters = {
     contestId: string;
@@ -37,8 +32,6 @@ export const ContestManagementLayout: FC = () => {
         data: contest,
     } = useContest(BigInt(/\d+/g.test(contestId) ? contestId : "0"));
 
-    const { user } = useAuthStore();
-
     const {
         isSuccess: isMemberSuccess,
         isError: isMemberError,
@@ -50,6 +43,14 @@ export const ContestManagementLayout: FC = () => {
 
         navigate("..");
     }, [isError, navigate]);
+
+    const member = members?.find((it) => it.contest_id === contest?.id);
+
+    const canViewPrivate = useContestPermission(
+        ContestMemberPermissions.VIEW_PRIVATE,
+        isSuccess ? contest : undefined,
+        member
+    );
 
     const { t } = useTranslation();
 
@@ -91,17 +92,7 @@ export const ContestManagementLayout: FC = () => {
 
     if (!isSuccess || !isMemberSuccess) return <div>Loading...</div>;
 
-    const member = members.find((it) => it.contest_id === contest.id);
-
-    if (
-        (!member ||
-            !hasContestPermission(
-                member.contest_permissions,
-                ContestMemberPermissions.VIEW_PRIVATE
-            )) &&
-        !hasAdminPermission(user.permissions, AdminPermissions.VIEW_CONTEST)
-    )
-        return <Navigate to={".."} />;
+    if (!canViewPrivate) return <Navigate to={".."} />;
 
     return (
         <div tw={"flex justify-center w-full"}>

--- a/apps/frontend/src/pages/management/contest/announcements/ContestAnnouncementsPage.tsx
+++ b/apps/frontend/src/pages/management/contest/announcements/ContestAnnouncementsPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import React, { FC, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -50,9 +50,9 @@ export const ContestAnnouncementsPage: FC = () => {
         <div tw={"flex gap-2 w-full justify-center"}>
             <div tw={"flex flex-col items-center gap-6 w-full"}>
                 <CanContestMember
+                    contest={contest}
                     member={member}
                     permission={ContestMemberPermissions.CREATE_ANNOUNCEMENT}
-                    adminPermission={AdminPermissions.EDIT_CONTEST}
                 >
                     <form onSubmit={onSubmit}>
                         <div tw={"flex flex-col gap-2 w-96"}>

--- a/apps/frontend/src/pages/management/contest/overview/ContestOverviewPage.tsx
+++ b/apps/frontend/src/pages/management/contest/overview/ContestOverviewPage.tsx
@@ -45,7 +45,7 @@ const ModifyContestSchema = z.object({
 });
 
 export const ContestOverviewPage: FC = () => {
-    const { contest } = useContestContext();
+    const { contest, member } = useContestContext();
 
     const defaultValues = {
         name: contest.name,
@@ -443,7 +443,7 @@ export const ContestOverviewPage: FC = () => {
                     </TitledSection>
                 </div>
             </div>
-            {problems && <Leaderboard contest={contest} problems={problems} />}
+            {problems && <Leaderboard contest={contest} problems={problems} selfMember={member} />}
         </div>
     );
 };

--- a/apps/frontend/src/pages/management/contest/problems/ContestProblemManagePage.tsx
+++ b/apps/frontend/src/pages/management/contest/problems/ContestProblemManagePage.tsx
@@ -1,4 +1,4 @@
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useEffect, useState } from "react";
 import { FiPlus } from "react-icons/all";
 import { useParams } from "react-router";
@@ -44,7 +44,7 @@ export const ContestProblemManagePage: FC = () => {
         setIsReevaluating((submissions ?? []).some((s) => s.reevaluation));
     }, [submissions]);
 
-    const { member } = useContestContext();
+    const { contest, member } = useContestContext();
 
     const [modalOpen, setModalOpen] = useState(false);
 
@@ -60,9 +60,9 @@ export const ContestProblemManagePage: FC = () => {
                     <SimpleButton>Manage Generators</SimpleButton>
                 </Link>
                 <CanContestMember
+                    contest={contest}
                     member={member}
                     permission={ContestMemberPermissions.EDIT}
-                    adminPermission={AdminPermissions.EDIT_CONTEST}
                 >
                     <SimpleButton prependIcon={FiPlus} onClick={() => setModalOpen(true)}>
                         {t("contests.management.individual.problems.cluster.createButton")}

--- a/apps/frontend/src/pages/management/contest/problems/ContestProblemsPage.tsx
+++ b/apps/frontend/src/pages/management/contest/problems/ContestProblemsPage.tsx
@@ -1,4 +1,4 @@
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useState } from "react";
 import { FiPlus } from "react-icons/all";
 
@@ -23,9 +23,9 @@ export const ContestProblemsPage: FC = () => {
     return (
         <div tw={"w-full flex flex-col items-end justify-center gap-4"}>
             <CanContestMember
+                contest={contest}
                 member={member}
                 permission={ContestMemberPermissions.EDIT}
-                adminPermission={AdminPermissions.EDIT_CONTEST}
             >
                 <SimpleButton prependIcon={FiPlus} onClick={() => setModalOpen(true)}>
                     {t("contests.management.individual.problems.createButton")}

--- a/apps/frontend/src/pages/management/contest/problems/clusters/ContestClusterManagePage.tsx
+++ b/apps/frontend/src/pages/management/contest/problems/clusters/ContestClusterManagePage.tsx
@@ -1,4 +1,4 @@
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useState } from "react";
 import { FiPlus } from "react-icons/all";
 import { useParams } from "react-router";
@@ -29,7 +29,7 @@ type Properties = {
 export const ContestClusterManagePage: FC = () => {
     const { problemId, clusterId } = useParams<Properties>();
 
-    const { member } = useContestContext();
+    const { contest, member } = useContestContext();
 
     const { data: cluster } = useCluster([BigInt(problemId ?? 0), BigInt(clusterId ?? 0)], {
         refetchInterval: (data) => (data?.status === "pending" ? 500 : 5000),
@@ -57,9 +57,9 @@ export const ContestClusterManagePage: FC = () => {
                 )}
                 <div tw={"w-full flex flex-col gap-6 items-end"}>
                     <CanContestMember
+                        contest={contest}
                         member={member}
                         permission={ContestMemberPermissions.EDIT}
-                        adminPermission={AdminPermissions.EDIT_CONTEST}
                     >
                         <SimpleButton prependIcon={FiPlus} onClick={() => setModalOpen(true)}>
                             {t(

--- a/apps/frontend/src/pages/management/contest/problems/generators/GeneratorManagePage.tsx
+++ b/apps/frontend/src/pages/management/contest/problems/generators/GeneratorManagePage.tsx
@@ -1,4 +1,4 @@
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useState } from "react";
 import { FiEdit, FiPlus, FiTrash2 } from "react-icons/all";
 import { useParams } from "react-router";
@@ -27,7 +27,7 @@ export const GeneratorManagePage: FC = () => {
     const { problemId } = useParams<Properties>();
     const { data: problem } = useProblem(BigInt(problemId ?? 0));
     const { data: generators } = useAllGenerators([BigInt(problemId ?? 0)]);
-    const { member } = useContestContext();
+    const { contest, member } = useContestContext();
     const { mutate: deleteGenerator } = useDeleteGenerator(BigInt(problemId ?? 0));
     const [modalOpen, setModalOpen] = useState(false);
 
@@ -42,9 +42,9 @@ export const GeneratorManagePage: FC = () => {
             <div tw={"w-full flex justify-between items-center"}>
                 <h2 tw={"text-2xl font-bold"}>Generators for {problem?.title}</h2>
                 <CanContestMember
+                    contest={contest}
                     member={member}
                     permission={ContestMemberPermissions.EDIT}
-                    adminPermission={AdminPermissions.EDIT_CONTEST}
                 >
                     <SimpleButton prependIcon={FiPlus} onClick={() => setModalOpen(true)}>
                         Create Generator
@@ -89,9 +89,9 @@ export const GeneratorManagePage: FC = () => {
                                             <SimpleButton prependIcon={FiEdit}>Edit</SimpleButton>
                                         </Link>
                                         <CanContestMember
+                                            contest={contest}
                                             member={member}
                                             permission={ContestMemberPermissions.EDIT}
-                                            adminPermission={AdminPermissions.EDIT_CONTEST}
                                         >
                                             <SimpleButton
                                                 prependIcon={FiTrash2}

--- a/apps/frontend/src/pages/management/contest/questions/ContestThreadDetailPage.tsx
+++ b/apps/frontend/src/pages/management/contest/questions/ContestThreadDetailPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AdminPermissions, ContestMemberPermissions } from "@kontestis/models";
+import { ContestMemberPermissions } from "@kontestis/models";
 import { FC, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { FiArrowLeft } from "react-icons/all";
@@ -121,9 +121,9 @@ export const ContestThreadDetailPage: FC = () => {
                 </div>
             </div>
             <CanContestMember
+                contest={contest}
                 member={member}
                 permission={ContestMemberPermissions.ANSWER_QUESTIONS}
-                adminPermission={AdminPermissions.EDIT_CONTEST}
             >
                 <form onSubmit={onSubmit} tw={"flex flex-col gap-2"}>
                     <label tw={"text-sm pl-1"}>

--- a/apps/frontend/src/pages/submissions/SubmissionTestcaseTable.tsx
+++ b/apps/frontend/src/pages/submissions/SubmissionTestcaseTable.tsx
@@ -1,25 +1,17 @@
-import {
-    AdminPermissions,
-    ContestMemberPermissions,
-    hasAdminPermission,
-    hasContestPermission,
-    Snowflake,
-} from "@kontestis/models";
+import { ContestMemberPermissions, Snowflake } from "@kontestis/models";
 import { FC, useCallback } from "react";
 import { FiChevronsLeft, FiDownload, FiX } from "react-icons/all";
 import tw from "twin.macro";
 
 import { http, wrapAxios } from "../../api/http";
-import { CanContestMember } from "../../components/CanContestMember";
 import { Table, TableHeadItem, TableHeadRow, TableItem, TableRow } from "../../components/Table";
 import { Translated } from "../../components/Translated";
 import { useContest } from "../../hooks/contest/useContest";
-import { useSelfContestMembers } from "../../hooks/contest/useSelfContestMembers";
+import { useContestPermission } from "../../hooks/contest/useContestPermission";
 import { useProblem } from "../../hooks/problem/useProblem";
 import { useSubmission } from "../../hooks/submission/useSubmission";
 import { useSubmissionTestcases } from "../../hooks/submission/useSubmissionTestcases";
 import { useTranslation } from "../../hooks/useTranslation";
-import { useAuthStore } from "../../state/auth";
 import { downloadFile } from "../../util/download";
 
 type Properties = {
@@ -42,12 +34,10 @@ export const SubmissionTestcaseTable: FC<Properties> = ({
     const { data: submission } = useSubmission(submissionId);
     const { data: problem } = useProblem(submission?.problem_id ?? 0n, { enabled: !!submission });
     const { data: contest } = useContest(problem?.contest_id ?? 0n, { enabled: !!problem });
-    const { data: members } = useSelfContestMembers();
-    const member = (members ?? []).find((member) => !!contest && member.contest_id === contest.id);
+
+    const canViewPrivate = useContestPermission(ContestMemberPermissions.VIEW_PRIVATE, contest);
 
     const { data: testcaseSubmissions } = useSubmissionTestcases(clusterSubmissionId);
-
-    const { user } = useAuthStore();
 
     const downloadSubmissionFile = useCallback(
         async (testcaseId: Snowflake, type: "in" | "out" | "sout") => {
@@ -82,22 +72,12 @@ export const SubmissionTestcaseTable: FC<Properties> = ({
                     <TableHeadItem>{t("submissions.table.head.time")}</TableHeadItem>
                     <TableHeadItem>{t("submissions.table.head.memory")}</TableHeadItem>
                     <TableHeadItem>{t("submissions.table.head.points")}</TableHeadItem>
-                    {isContestFinished || isSample ? (
+                    {(isContestFinished || isSample || canViewPrivate) && (
                         <>
                             <TableHeadItem>Input</TableHeadItem>
                             <TableHeadItem>Output</TableHeadItem>
                             <TableHeadItem>Submission</TableHeadItem>
                         </>
-                    ) : (
-                        <CanContestMember
-                            member={member}
-                            permission={ContestMemberPermissions.VIEW_PRIVATE}
-                            adminPermission={AdminPermissions.EDIT_CONTEST}
-                        >
-                            <TableHeadItem>Input</TableHeadItem>
-                            <TableHeadItem>Output</TableHeadItem>
-                            <TableHeadItem>Submission</TableHeadItem>
-                        </CanContestMember>
                     )}
                 </TableHeadRow>
             </thead>
@@ -127,17 +107,7 @@ export const SubmissionTestcaseTable: FC<Properties> = ({
                                     {ts.awarded_score ?? "?"}
                                 </Translated>
                             </TableItem>
-                            {(isContestFinished ||
-                                isSample ||
-                                hasAdminPermission(
-                                    user.permissions,
-                                    AdminPermissions.EDIT_CONTEST
-                                ) ||
-                                (member &&
-                                    hasContestPermission(
-                                        member.contest_permissions,
-                                        ContestMemberPermissions.VIEW_PRIVATE
-                                    ))) && (
+                            {(isContestFinished || isSample || canViewPrivate) && (
                                 <>
                                     <TableItem>
                                         {files.includes(`${ts.testcase_id}.in`) ? (

--- a/packages/models/src/permissions/ContestMemberPermissions.ts
+++ b/packages/models/src/permissions/ContestMemberPermissions.ts
@@ -1,7 +1,6 @@
 import { hasPermission, PermissionData } from "permissio";
 
-import { AdminPermissions, hasAdminPermission } from "./AdminPermissions";
-import { OrganisationPermissions } from "./OrganisationPermissions";
+import { hasOrganisationPermission, OrganisationPermissions } from "./OrganisationPermissions";
 
 export enum ContestMemberPermissions {
     ADMIN,
@@ -39,12 +38,19 @@ export const ContestMemberPermissionNames = ((values = Object.keys(ContestMember
 export const hasContestPermission = (
     data: PermissionData,
     permission: ContestMemberPermissions,
+    orgMemberPermissions?: PermissionData,
     adminPermissions?: PermissionData
 ) => {
-    return (
-        hasPermission(data, ContestMemberPermissions.ADMIN) ||
-        hasPermission(data, permission) ||
-        (adminPermissions !== undefined &&
-            hasAdminPermission(adminPermissions, AdminPermissions.ADMIN))
-    );
+    const permissionKey = ContestMemberPermissions[permission] as ContestMemberPermissionKeys;
+
+    if (
+        hasOrganisationPermission(
+            orgMemberPermissions,
+            ContestMemberToOrganisationPermissionMap[permissionKey],
+            adminPermissions
+        )
+    )
+        return true;
+
+    return hasPermission(data, ContestMemberPermissions.ADMIN) || hasPermission(data, permission);
 };

--- a/packages/models/src/permissions/OrganisationPermissions.ts
+++ b/packages/models/src/permissions/OrganisationPermissions.ts
@@ -1,4 +1,6 @@
-import { AdminPermissions } from "./AdminPermissions";
+import { hasPermission, PermissionData } from "permissio";
+
+import { AdminPermissions, hasAdminPermission } from "./AdminPermissions";
 
 export enum OrganisationPermissions {
     ADMIN,
@@ -37,3 +39,24 @@ export type OrganisationPermissionKeys = keyof typeof OrganisationPermissions;
 
 export const OrganisationPermissionNames = ((values = Object.keys(OrganisationPermissions)) =>
     values.slice(values.length / 2))() as OrganisationPermissionKeys[];
+
+export const hasOrganisationPermission = (
+    orgMemberPermissions: PermissionData | undefined,
+    permission: OrganisationPermissions,
+    adminPermissions?: PermissionData
+) => {
+    const permissionKey = OrganisationPermissions[permission] as OrganisationPermissionKeys;
+
+    if (
+        adminPermissions !== undefined &&
+        hasAdminPermission(adminPermissions, OrganisationToAdminPermissionMap[permissionKey])
+    )
+        return true;
+
+    if (orgMemberPermissions === undefined) return false;
+
+    return (
+        hasPermission(orgMemberPermissions, OrganisationPermissions.ADMIN) ||
+        hasPermission(orgMemberPermissions, permission)
+    );
+};


### PR DESCRIPTION
## Summary

- The frontend was skipping the **organisation-level** permission tier in its permission checks, causing org admins who aren't direct contest members to be blocked from contest management, leaderboards, and problem visibility
- Added `hasOrganisationPermission` pure function to models and updated `hasContestPermission` to support the full admin → org → contest cascade (backwards-compatible)
- Created `useContestPermission` hook that wires `useAuthStore`, `useSelfContestMembers`, and `useSelfOrganisationMembers` into the cascade
- Rewrote `CanContestMember` to use the hook internally, removing the error-prone `adminPermission` prop that callers had to manually specify
- Fixed all standalone permission checks across ManagementPage, ContestManagementLayout, ContestViewPage, Leaderboard, and SubmissionTestcaseTable

## Test plan

- [ ] Verify org admin (not a contest member) can see contest in management list
- [ ] Verify org admin can access contest management layout
- [ ] Verify org admin can see leaderboard when set to "after contest only"
- [ ] Verify org admin can see problems before contest starts
- [ ] Verify org admin can see testcase files during contest
- [ ] Verify regular contest members still see correct UI based on their permissions
- [ ] Verify global admins retain full access
- [ ] Verify unauthenticated/unprivileged users are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)